### PR TITLE
Try to parse eslint as JSON

### DIFF
--- a/lib/examine-eslintrc.js
+++ b/lib/examine-eslintrc.js
@@ -72,6 +72,14 @@ module.exports = function(options) {
         data = require(filePath);
     } else {
         data = fs.readFileSync(filePath);
+
+        // If we're already assuming that it's JSON, lets
+        // try parsing it as JSON
+        try {
+            data = JSON.parse(data);
+        } catch (e) {
+            verboseLog(e);
+        }
     }
 
     // work through all rules, setting passed = true/false


### PR DESCRIPTION
fs.readFileSync is reading the files as a Buffer and are not exposing a JSON object by default. For the sake of sanity we should try parsing as JSON since we will fail otherwise anyway.

Also, the current solution actually means that a newly generated component will be failed by gfp-doctor.