### PR TITLE
Gfp-doctor no longer crashes when trying to read a .eslintrc with inv…

### DIFF
--- a/lib/examine-eslintrc.js
+++ b/lib/examine-eslintrc.js
@@ -79,6 +79,11 @@ module.exports = function(options) {
             data = JSON.parse(data);
         } catch (e) {
             verboseLog(e);
+            console.error(
+                chalk.red(`${abortPrefix}:`),
+                'Could not interpet eslint. This issue may occur when you have invalid json in your .eslintrc'
+            );
+            return addSkipped(rulesConf);
         }
     }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
 module.exports = function(msg, options) {
-    options = options instanceof Object ? options : {};
+    options = Object(options);
 
     if (options.verbose) {
         console.log(msg);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,6 @@
 module.exports = function(msg, options) {
+    options = options instanceof Object ? options : {};
+
     if (options.verbose) {
         console.log(msg);
     }


### PR DESCRIPTION
When trying to read a .eslintrc that contains a comment or some form of invalid json, gfp-doctor will crash instead of notifying the user and continuing the examination.