### PR TITLE
Update to test for puppeteer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.DS_Store
+
+# IDE files/folders
+.idea
+
 # Runtime data
 pids
 *.pid

--- a/lib/examine-karma-conf.js
+++ b/lib/examine-karma-conf.js
@@ -19,6 +19,14 @@ const rulesConf = {
                 "'./node_modules/angular/angular.js', \n" +
                 "'./node_modules/angular-mocks/angular-mocks.js'",
             fn: notUsingAngularFromCdn
+        },
+        {
+            desc:
+                'Using ChromeHeadless browser',
+            errorMsg:
+            'Remove "phantomjs" as browser from karma.conf.js.\n' +
+            'Add "ChromeHeadless" as browser in karma.conf.js \n',
+            fn: notUsingChromeAsBrowser
         }
     ]
 };
@@ -74,4 +82,15 @@ function notUsingAngularFromCdn(karmaConfig) {
     });
 
     return !foundAngularFromCdn;
+}
+
+function notUsingChromeAsBrowser(karmaConfig) {
+    if(!karmaConfig || !karmaConfig.browser) {
+        return true;
+    }
+
+    if(karmaConfig.browser.indexOf('ChromeHeadless') < 0) {
+        return false;
+    }
+
 }

--- a/lib/examine-package.js
+++ b/lib/examine-package.js
@@ -45,16 +45,18 @@ const rulesConf = {
             fn: hasNpmLintScript
         },
         {
-            desc: 'should be using phantomjs-prebuilt',
+            desc: 'should be using puppeteer',
             errorMsg:
                 'remove phantomjs from package.json, then run \n' +
-                'npm install --save-dev phantomjs-prebuilt',
-            fn: shouldUsePhantomjsPrebuilt
+                'npm install --save-dev puppeteer',
+            fn: shouldUsePuppeteer
         },
         {
-            desc: 'should use "karma-phantomjs-launcher" 1 and up',
-            errorMsg: 'set "karma-phantomjs-launcher" to use "^1.0.0"',
-            fn: shouldUsePhantomjsLauncher1
+            desc: 'should be using headless Chrome',
+            errorMsg:
+                'remove "karma-phantomjs-launcher", then run' +
+                'npm install --save-dev karma-chrome-launcher',
+            fn: shouldUseChromeLauncher
         },
         {
             desc: 'should use prepush hooks',
@@ -181,24 +183,24 @@ function hasNpmLintScript(json) {
     }
 }
 
-function shouldUsePhantomjsPrebuilt(json) {
+function shouldUsePuppeteer(json) {
     if (json.devDependencies) {
-        if (json.devDependencies['phantomjs']) {
+        if (json.devDependencies['phantomjs'] || json.devDependencies['phantomjs-prebuilt']) {
             return false;
         }
-        if (json.devDependencies['phantomjs-prebuilt']) {
+        if (json.devDependencies['puppeteer']) {
             return true;
         }
     }
 }
 
-function shouldUsePhantomjsLauncher1(json) {
+function shouldUseChromeLauncher(json) {
     if (json.devDependencies) {
         if (json.devDependencies['karma-phantomjs-launcher']) {
-            return semver.satisfies(
-                '1.0.0',
-                json.devDependencies['karma-phantomjs-launcher']
-            );
+            return false;
+        }
+        if(json.devDependencies['karma-chrome-launcher']) {
+            return true;
         }
     }
 }

--- a/test/mocks/package_eslint_3_0_1.json
+++ b/test/mocks/package_eslint_3_0_1.json
@@ -19,13 +19,12 @@
         "eslint": "^3.19.0",
         "eslint-config-gfp": "^3.0.1",
         "jasmine-core": "2.x",
-        "karma": "1.3.x",
+        "karma": "1.7.x",
         "karma-coverage": "1.x",
         "karma-jasmine": "1.x",
-        "karma-phantomjs-launcher": "1.x",
+        "karma-chrome-launcher": "^2.2.0",
         "karma-spec-reporter": "0.x",
-        "phantomjs-polyfill": "0.0.1",
-        "phantomjs-prebuilt": "2.x",
+        "puppeteer": "^0.13.0",
         "require-polyfill": "git+ssh://git@stash.mrgreen.zone:7999/gar/require-polyfill.git#v1.0.0"
     },
     "repository": {


### PR DESCRIPTION
This PR updates the tests to check that the codebase uses `puppeteer` and `ChromeHeadless` rather than `PhantomJS` to run unit tests.

I also added a IDE folder specific section in the gitignore in order to not commit IDE config folders.